### PR TITLE
refactor `{request,cancel}Frame`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,13 @@
 export default function requestAnimationFrames() {
 	const hasRaf = typeof globalThis.requestAnimationFrame === 'function';
 
-	const requestFrame = callback => hasRaf
-		? globalThis.requestAnimationFrame(callback)
-		: setTimeout(() => callback(performance.now()), 16);
+	const requestFrame = hasRaf
+		? globalThis.requestAnimationFrame
+		: callback => setTimeout(() => callback(performance.now()), 16);
 
-	const cancelFrame = id => {
-		if (hasRaf) {
-			globalThis.cancelAnimationFrame(id);
-		} else {
-			clearTimeout(id);
-		}
-	};
+	const cancelFrame = hasRaf
+		? globalThis.cancelAnimationFrame
+		: id => clearTimeout(id);
 
 	return {
 		async * [Symbol.asyncIterator]() {


### PR DESCRIPTION
Instead of creating new functions on every iteration, use the fact that `hasRaf` is static and only create functions once (and don't create functions for global methods). I don't think this is a super important change, but could be beneficial for perf and simplicity.